### PR TITLE
fixes #2 by setting writer.filename to this->FileName

### DIFF
--- a/Source/vtkboneAIMWriter.cxx
+++ b/Source/vtkboneAIMWriter.cxx
@@ -120,6 +120,7 @@ void vtkboneAIMWriter::WriteData()
       vtkErrorMacro(<<"An output filename must be specified.");
       return;
     }
+  writer.filename = this->FileName;
 
   // Do this again - they may have changed.
   input->GetDimensions(dimension);


### PR DESCRIPTION
This will allow the AIMWriter to write.

However, I do not believe the writer is functioning properly. The issue with this PR is that a user may not realize the error, write many AIMs, and find the error later when it cannot be fixed. That's be an issue if they, say, deleted previous data.